### PR TITLE
SPRO-33:  Support Street Address Line 3 Field on Subscribe Pro API calls

### DIFF
--- a/Model/Quote/Payment/GetPaymentProfileId.php
+++ b/Model/Quote/Payment/GetPaymentProfileId.php
@@ -127,6 +127,7 @@ class GetPaymentProfileId
             AddressInterface::COMPANY => $billingAddress->getCompany(),
             AddressInterface::STREET1 => $billingAddress->getStreetLine(1),
             AddressInterface::STREET2 => $billingAddress->getStreetLine(2),
+            AddressInterface::STREET3 => $billingAddress->getStreetLine(3),
             AddressInterface::CITY => $billingAddress->getCity(),
             AddressInterface::REGION => $billingAddress->getRegionCode(),
             AddressInterface::POSTCODE => $billingAddress->getPostcode(),

--- a/Service/OrderCallback/ResponseProcessor.php
+++ b/Service/OrderCallback/ResponseProcessor.php
@@ -108,6 +108,7 @@ class ResponseProcessor
             'company' => $orderAddress->getCompany(),
             'street1' => $orderAddress->getStreetLine(1),
             'street2' => $orderAddress->getStreetLine(2),
+            'street3' => $orderAddress->getStreetLine(3),
             'city' => $orderAddress->getCity(),
             'region' => $orderAddress->getRegionCode(),
             'postcode' => $orderAddress->getPostcode(),


### PR DESCRIPTION
Add street3 fields to Swarming\SubscribePro\Model\Quote\Payment\GetPaymentProfileId and Swarming\SubscribePro\Service\OrderCallback\ResponseProcessor